### PR TITLE
[BACKLOG-4490] Changed Karaf to version 3.0.3. Added the org.apache.util.maven to karaf classpath, and change start level for the Pentaho deployment dependencies to start before the boot features.

### DIFF
--- a/assemblies/karaf/features/src/main/resources/features.xml
+++ b/assemblies/karaf/features/src/main/resources/features.xml
@@ -4,15 +4,15 @@
     <feature>cxf</feature>
     <feature>cxf-http-async</feature>
     <feature>war</feature>
-    <bundle>wrap:mvn:com.clearspring.analytics/stream/2.7.0</bundle>
-    <bundle>mvn:org.apache.felix/org.apache.felix.http.api/2.2.2</bundle>
-    <bundle>mvn:com.google.guava/guava/16.0.1</bundle>
-    <bundle>mvn:com.googlecode.json-simple/json-simple/1.1.1</bundle>
-    <bundle>mvn:commons-io/commons-io/2.4</bundle>
-    <bundle>mvn:org.codehaus.jackson/jackson-jaxrs/1.9.13</bundle>
-    <bundle>mvn:org.codehaus.jackson/jackson-xc/1.9.13</bundle>
-    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.13</bundle>
-    <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.13</bundle>
+    <bundle>wrap:mvn:com.clearspring.analytics/stream/${clearspring.analytics-stream.version}</bundle>
+    <bundle>mvn:org.apache.felix/org.apache.felix.http.api/${felix.http.api.version}</bundle>
+    <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
+    <bundle>mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>
+    <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-jaxrs/${jackson.version}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-xc/${jackson.version}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/${jackson.version}</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/${jackson.version}</bundle>
     <bundle>mvn:pentaho/pentaho-data-profiling-api-core/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-data-profiling-api-doc-rest/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-data-profiling-api-json/${project.version}</bundle>

--- a/assemblies/karaf/pom.xml
+++ b/assemblies/karaf/pom.xml
@@ -18,12 +18,6 @@
   <packaging>pom</packaging>
   <properties>
     <package.features>true</package.features>
-    <ce.version>${project.version}</ce.version>
-    <karaf.version>2.3.5</karaf.version>
-    <cxf.version>2.7.11</cxf.version>
-    <logback.version>1.1.2</logback.version>
-    <servlet.version>2.5</servlet.version>
-    <jersey.version>1.18.1</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -117,6 +111,27 @@
                   <outputDirectory>target/dependencies</outputDirectory>
                 </artifactItem>
               </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.karaf</groupId>
+                  <artifactId>org.apache.karaf.util</artifactId>
+                  <type>jar</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/standalone-karaf-lib</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/wars</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
         </executions>

--- a/assemblies/karaf/src/main/descriptors/standalone-assembly.xml
+++ b/assemblies/karaf/src/main/descriptors/standalone-assembly.xml
@@ -27,29 +27,43 @@
 
     <!-- Expanded Karaf Standard Distribution -->
     <fileSet>
-      <directory>target/dependencies/apache-karaf-2.3.5</directory>
-      <outputDirectory>/apache-karaf-2.3.5</outputDirectory>
+      <directory>target/dependencies/apache-karaf-${karaf.version}</directory>
+      <outputDirectory>/apache-karaf-${karaf.version}</outputDirectory>
       <excludes>
         <exclude>etc/org.apache.karaf.features.cfg</exclude>
         <exclude>etc/startup.properties</exclude>
+        <exclude>etc/custom.properties</exclude>
       </excludes>
     </fileSet>
 
     <fileSet>
-      <directory>src/main/resources/standalone/karaf/</directory>
+      <directory>target/classes/standalone/karaf/</directory>
       <lineEnding>unix</lineEnding>
-      <outputDirectory>/apache-karaf-2.3.5</outputDirectory>
+      <outputDirectory>/apache-karaf-${karaf.version}</outputDirectory>
+      <excludes>
+        <exclude>**/*.formatted</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
     </fileSet>
 
     <fileSet>
-      <directory>src/main/resources/shared/karaf/</directory>
+      <directory>target/classes/shared/karaf/</directory>
       <lineEnding>unix</lineEnding>
-      <outputDirectory>/apache-karaf-2.3.5</outputDirectory>
+      <outputDirectory>/apache-karaf-${karaf.version}</outputDirectory>
+      <excludes>
+        <exclude>**/*.formatted</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
     </fileSet>
 
     <fileSet>
       <directory>target/standalone-features-repo</directory>
-      <outputDirectory>/apache-karaf-2.3.5/system</outputDirectory>
+      <outputDirectory>/apache-karaf-${karaf.version}/system</outputDirectory>
+    </fileSet>
+    
+    <fileSet>
+      <directory>target/standalone-karaf-lib</directory>
+      <outputDirectory>/apache-karaf-${karaf.version}/lib</outputDirectory>
     </fileSet>
   </fileSets>
 

--- a/assemblies/karaf/src/main/resources/standalone/karaf/etc/custom.properties
+++ b/assemblies/karaf/src/main/resources/standalone/karaf/etc/custom.properties
@@ -17,19 +17,14 @@
 #
 ################################################################################
 
-respectStartLvlDuringFeatureStartup=false
+#
+# All the values specified here will override the default values given
+# in config.properties.
+#
 
-#
-# Comma separated list of features repositories to register by default
-#
-featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.version}/xml/features,mvn:io.hawt/hawtio-karaf/${hawtio.version}/xml/features,mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features,mvn:pentaho-karaf-features/pentaho-data-profiling-ce/${project.version}/xml/features
+karaf.systemBundlesStartLevel=50
 
-#
-# Comma separated list of features to install at startup
-#
-featuresBoot=config,ssh,management,kar,pentaho-data-profiling-ce-standalone
+org.osgi.framework.system.packages.extra= \
+ org.apache.karaf.util.maven; version="${karaf.version}"
 
-#
-# Defines if the boot features are started in asynchronous mode (in a dedicated thread)
-#
-featuresBootAsynchronous=false
+org.osgi.framework.storage.clean=onFirstInit

--- a/assemblies/karaf/src/main/resources/standalone/karaf/etc/startup.properties
+++ b/assemblies/karaf/src/main/resources/standalone/karaf/etc/startup.properties
@@ -20,68 +20,50 @@
 # This file allows you to control the start level of each bundle.
 #
 
-#
-# Startup core services like logging
-#
-org/ops4j/pax/url/pax-url-mvn/1.3.7/pax-url-mvn-1.3.7.jar=5
-org/ops4j/pax/url/pax-url-wrap/1.3.7/pax-url-wrap-1.3.7.jar=5
-org/ops4j/pax/logging/pax-logging-api/1.7.2/pax-logging-api-1.7.2.jar=8
-org/ops4j/pax/logging/pax-logging-service/1.7.2/pax-logging-service-1.7.2.jar=8
-org/apache/felix/org.apache.felix.configadmin/1.6.0/org.apache.felix.configadmin-1.6.0.jar=10
-org/apache/felix/org.apache.felix.fileinstall/3.2.8/org.apache.felix.fileinstall-3.2.8.jar=11
+#Bundles to be started on startup, with startlevel
 
-#
-# The rest of the services..
-#
-org/ow2/asm/asm-all/4.1/asm-all-4.1.jar=20
-org/apache/aries/org.apache.aries.util/1.1.0/org.apache.aries.util-1.1.0.jar=20
-org/apache/aries/proxy/org.apache.aries.proxy.api/1.0.0/org.apache.aries.proxy.api-1.0.0.jar=20
-org/apache/aries/proxy/org.apache.aries.proxy.impl/1.0.2/org.apache.aries.proxy.impl-1.0.2.jar=20
-org/apache/aries/blueprint/org.apache.aries.blueprint.api/1.0.0/org.apache.aries.blueprint.api-1.0.0.jar=20
-org/apache/aries/blueprint/org.apache.aries.blueprint.core/1.4.0/org.apache.aries.blueprint.core-1.4.0.jar=20
-org/apache/aries/blueprint/org.apache.aries.blueprint.cm/1.0.3/org.apache.aries.blueprint.cm-1.0.3.jar=20
-
-org/apache/karaf/shell/org.apache.karaf.shell.console/2.3.5/org.apache.karaf.shell.console-2.3.5.jar=25
-
-org/apache/karaf/shell/org.apache.karaf.shell.osgi/2.3.5/org.apache.karaf.shell.osgi-2.3.5.jar=30
-org/apache/karaf/shell/org.apache.karaf.shell.log/2.3.5/org.apache.karaf.shell.log-2.3.5.jar=30
-org/apache/karaf/shell/org.apache.karaf.shell.packages/2.3.5/org.apache.karaf.shell.packages-2.3.5.jar=30
-org/apache/karaf/shell/org.apache.karaf.shell.commands/2.3.5/org.apache.karaf.shell.commands-2.3.5.jar=30
-org/apache/karaf/shell/org.apache.karaf.shell.dev/2.3.5/org.apache.karaf.shell.dev-2.3.5.jar=30
-org/apache/karaf/jaas/org.apache.karaf.jaas.config/2.3.5/org.apache.karaf.jaas.config-2.3.5.jar=30
-org/apache/karaf/jaas/org.apache.karaf.jaas.modules/2.3.5/org.apache.karaf.jaas.modules-2.3.5.jar=30
-org/apache/karaf/jaas/org.apache.karaf.jaas.command/2.3.5/org.apache.karaf.jaas.command-2.3.5.jar=30
-org/apache/karaf/features/org.apache.karaf.features.core/2.3.5/org.apache.karaf.features.core-2.3.5.jar=30
-org/apache/karaf/features/org.apache.karaf.features.command/2.3.5/org.apache.karaf.features.command-2.3.5.jar=30
-org/apache/karaf/features/org.apache.karaf.features.management/2.3.5/org.apache.karaf.features.management-2.3.5.jar=30
-
-org/apache/karaf/diagnostic/org.apache.karaf.diagnostic.core/2.3.5/org.apache.karaf.diagnostic.core-2.3.5.jar=30
-org/apache/karaf/diagnostic/org.apache.karaf.diagnostic.common/2.3.5/org.apache.karaf.diagnostic.common-2.3.5.jar=30
-org/apache/karaf/diagnostic/org.apache.karaf.diagnostic.command/2.3.5/org.apache.karaf.diagnostic.command-2.3.5.jar=30
-org/apache/karaf/diagnostic/org.apache.karaf.diagnostic.management/2.3.5/org.apache.karaf.diagnostic.management-2.3.5.jar=30
-
-org/apache/karaf/management/org.apache.karaf.management.server/2.3.5/org.apache.karaf.management.server-2.3.5.jar=30
-org/apache/aries/jmx/org.apache.aries.jmx.api/1.1.0/org.apache.aries.jmx.api-1.1.0.jar=30
-org/apache/aries/jmx/org.apache.aries.jmx.core/1.1.1/org.apache.aries.jmx.core-1.1.1.jar=30
-org/apache/aries/jmx/org.apache.aries.jmx.blueprint.api/1.1.0/org.apache.aries.jmx.blueprint.api-1.1.0.jar=30
-org/apache/aries/jmx/org.apache.aries.jmx.blueprint.core/1.1.0/org.apache.aries.jmx.blueprint.core-1.1.0.jar=30
-
-org/apache/karaf/admin/org.apache.karaf.admin.core/2.3.5/org.apache.karaf.admin.core-2.3.5.jar=30
-org/apache/karaf/admin/org.apache.karaf.admin.command/2.3.5/org.apache.karaf.admin.command-2.3.5.jar=30
-org/apache/karaf/admin/org.apache.karaf.admin.management/2.3.5/org.apache.karaf.admin.management-2.3.5.jar=30
-
-org/apache/mina/mina-core/2.0.7/mina-core-2.0.7.jar=30
-org/apache/sshd/sshd-core/0.8.0/sshd-core-0.8.0.jar=30
-org/apache/karaf/shell/org.apache.karaf.shell.ssh/2.3.5/org.apache.karaf.shell.ssh-2.3.5.jar=30
-
-org/apache/karaf/deployer/org.apache.karaf.deployer.spring/2.3.5/org.apache.karaf.deployer.spring-2.3.5.jar=28
-org/apache/karaf/deployer/org.apache.karaf.deployer.blueprint/2.3.5/org.apache.karaf.deployer.blueprint-2.3.5.jar=28
-org/apache/karaf/deployer/org.apache.karaf.deployer.features/2.3.5/org.apache.karaf.deployer.features-2.3.5.jar=30
-org/apache/karaf/deployer/org.apache.karaf.deployer.kar/2.3.5/org.apache.karaf.deployer.kar-2.3.5.jar=30
-org/apache/karaf/deployer/org.apache.karaf.deployer.wrap/2.3.5/org.apache.karaf.deployer.wrap-2.3.5.jar=30
+# feature: framework version: 3.0.3
 
 #Pentaho deployment dependencies
-com/googlecode/json-simple/json-simple/1.1.1/json-simple-1.1.1.jar=29
-com/google/guava/guava/16.0.1/guava-16.0.1.jar=29
-commons-io/commons-io/2.4/commons-io-2.4.jar=29
-pentaho/pentaho-platform-plugin-deployer/6.0-SNAPSHOT/pentaho-platform-plugin-deployer-6.0-SNAPSHOT.jar=30
+mvn\:com.googlecode.json-simple/json-simple/${json-simple.version} = 6
+mvn\:com.google.guava/guava/${guava.version} = 6
+mvn\:commons-io/commons-io/${commons-io.version} = 6
+mvn\:pentaho/pentaho-platform-plugin-deployer/${project.version} = 7
+
+
+mvn\:org.ops4j.pax.url/pax-url-aether/2.3.0 = 5
+mvn\:org.ops4j.pax.url/pax-url-wrap/2.3.0/jar/uber = 5
+mvn\:org.ops4j.pax.logging/pax-logging-api/1.8.1 = 8
+mvn\:org.ops4j.pax.logging/pax-logging-service/1.8.1 = 8
+mvn\:org.apache.karaf.service/org.apache.karaf.service.guard/${karaf.version} = 10
+mvn\:org.apache.felix/org.apache.felix.configadmin/1.8.0 = 10
+mvn\:org.apache.felix/org.apache.felix.fileinstall/3.4.2 = 11
+mvn\:org.ow2.asm/asm-all/5.0.3 = 12
+mvn\:org.apache.aries/org.apache.aries.util/1.1.0 = 20
+mvn\:org.apache.aries.proxy/org.apache.aries.proxy.api/1.0.1 = 20
+mvn\:org.apache.aries.proxy/org.apache.aries.proxy.impl/1.0.4 = 20
+mvn\:org.apache.aries.blueprint/org.apache.aries.blueprint.api/1.0.1 = 20
+mvn\:org.apache.aries.blueprint/org.apache.aries.blueprint.cm/1.0.5 = 20
+mvn\:org.apache.aries.blueprint/org.apache.aries.blueprint.core.compatibility/1.0.0 = 20
+mvn\:org.apache.aries.blueprint/org.apache.aries.blueprint.core/1.4.2 = 20
+mvn\:org.apache.karaf.deployer/org.apache.karaf.deployer.spring/${karaf.version} = 24
+mvn\:org.apache.karaf.deployer/org.apache.karaf.deployer.blueprint/${karaf.version} = 24
+mvn\:org.apache.karaf.deployer/org.apache.karaf.deployer.wrap/${karaf.version} = 24
+mvn\:org.apache.karaf.region/org.apache.karaf.region.core/${karaf.version} = 25
+mvn\:org.apache.karaf.features/org.apache.karaf.features.core/${karaf.version} = 25
+mvn\:org.apache.karaf.deployer/org.apache.karaf.deployer.features/${karaf.version} = 26
+mvn\:jline/jline/2.12 = 30
+mvn\:org.jledit/core/0.2.1 = 30
+mvn\:org.apache.karaf.features/org.apache.karaf.features.command/${karaf.version} = 30
+mvn\:org.apache.karaf.shell/org.apache.karaf.shell.console/${karaf.version} = 30
+mvn\:org.apache.karaf.jaas/org.apache.karaf.jaas.modules/${karaf.version} = 30
+mvn\:org.apache.karaf.jaas/org.apache.karaf.jaas.config/${karaf.version} = 30
+mvn\:org.apache.sshd/sshd-core/0.12.0 = 30
+mvn\:org.apache.karaf.bundle/org.apache.karaf.bundle.core/${karaf.version} = 30
+mvn\:org.apache.karaf.bundle/org.apache.karaf.bundle.command/${karaf.version} = 30
+mvn\:org.apache.karaf.shell/org.apache.karaf.shell.table/${karaf.version} = 30
+mvn\:org.apache.karaf.shell/org.apache.karaf.shell.help/${karaf.version} = 30
+mvn\:org.apache.karaf.system/org.apache.karaf.system.core/${karaf.version} = 30
+mvn\:org.apache.karaf.system/org.apache.karaf.system.command/${karaf.version} = 30
+mvn\:org.apache.karaf.shell/org.apache.karaf.shell.commands/${karaf.version} = 30
+mvn\:org.apache.aries.quiesce/org.apache.aries.quiesce.api/1.0.0 = 30

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -12,6 +12,15 @@
   <artifactId>pentaho-data-profiling-assemblies</artifactId>
   <packaging>pom</packaging>
 
+  <properties>
+    <karaf.version>3.0.3</karaf.version>
+    <commons-io.version>2.4</commons-io.version>
+    <hawtio.version>1.4.11</hawtio.version>
+    <camel.version>2.13.2</camel.version>
+    <clearspring.analytics-stream.version>2.7.0</clearspring.analytics-stream.version>
+    <felix.http.api.version>2.2.2</felix.http.api.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>pentaho</groupId>


### PR DESCRIPTION
Changed Karaf version from 2.3.5 to 3.0.3, as well as, the karaf features.xml version. Changed the features.xml and startup.properties to reflect the karaf version modification. 
Added the dependency org.apache.util and use it in the standalone-assembly to include its .jar file inside the lib folder of karaf. This way, the org.apache.util.maven is included in the karaf classpath. 
In startup.properties, I changed the start level for the Pentaho deployment dependencies to start before the boot features start because the protocol pentaho-platform-plugin-mvn used in the pentaho-data-profiling-ce-standalone feature depends on the pentaho-platform-plugin-deployer bundle.