### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/assemblies/karaf/pom.xml
+++ b/assemblies/karaf/pom.xml
@@ -15,7 +15,7 @@
     <module>features</module>
   </modules>
   <properties>
-    <jersey.version>1.18.1</jersey.version>
+    <jersey.version>1.19.1</jersey.version>
     <servlet.version>2.5</servlet.version>
     <karaf.version>2.3.5</karaf.version>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -70,13 +70,13 @@
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>1.9</version>
+      <version>1.19.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-json</artifactId>
-      <version>1.9</version>
+      <version>1.19.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor